### PR TITLE
update chains to current "SupportedChains" on Protocol

### DIFF
--- a/reference/supported-chains.md
+++ b/reference/supported-chains.md
@@ -14,17 +14,19 @@ Below is the full list of supported, reward-generating RelayChains, identical to
 | ------------------------------------------ | ------------------------- | --------- |
 | Arbitrum One                               | arbitrum-one              | 0066      |
 | AVAX                                       | avax-mainnet              | 0003      |
-| AVAX Archival                              | avax-archival             | 00A3      |
+| AVAX Archival                              | avax-archival             | A003      |
+| Base Mainnet                               | base-mainnet              | 0079      |
+| Base Testnet                               | base-testnet              | 0080      |
 | BOBA Mainnet                               | boba-mainnet              | 0048      |
 | Binance Smart Chain                        | bsc-mainnet               | 0004      |
 | Binance Smart Chain (Archival)             | bsc-archival              | 0010      |
+| Celestia Archival                          | celestia-archival         | A0CA      |
 | Celo Mainnet                               | celo-mainnet              | 0065      |
 | DFKchain Subnet                            | avax-dfk                  | 03DF      |
 | Dogechain Mainnet                          | dogechain-mainnet         | 0059      |
 | Ethereum Mainnet                           | eth-mainnet               | 0021      |
 | Ethereum Mainnet Archival                  | eth-archival              | 0022      |
 | Ethereum Mainnet Archival with trace calls | eth-trace                 | 0028      |
-| Ethereum Mainnet High Gas                  | ethereum-mainnet-high-gas | 0062      |
 | Evmos Mainnet                              | evmos-mainnet             | 0046      |
 | Fantom Mainnet                             | fantom-mainnet            | 0049      |
 | Fuse                                       | fuse-mainnet              | 0005      |
@@ -34,6 +36,7 @@ Below is the full list of supported, reward-generating RelayChains, identical to
 | Goerli                                     | eth-goerli                | 0026      |
 | Goerli Archival                            | goerli-archival           | 0063      |
 | Harmony Shard 0                            | harmony-0                 | 0040      |
+| Holesky testnet                            | holesky-fullnode-testnet  | 0081      |
 | IoTeX Mainnet                              | iotex-mainnet             | 0044      |
 | Kava Mainnet                               | kava-mainnet              | 0071      |
 | Kava Mainnet Archival                      | kava-mainnet-archival     | 0072      |
@@ -48,19 +51,22 @@ Below is the full list of supported, reward-generating RelayChains, identical to
 | Oasys Mainnet                              | oasys-mainnet             | 0070      |
 | Oasys Mainnet Archival                     | oasys-mainnet-archival    | 0069      |
 | Optimism Mainnet                           | optimism-mainnet          | 0053      |
+| Optimism Mainnet Archival                  | optimism-mainnet-archival | A053      |
 | Osmosis Mainnet                            | osmosis-mainnet           | 0054      |
 | Pocket Network Mainnet                     | mainnet                   | 0001      |
 | Polygon Matic                              | poly-mainnet              | 0009      |
 | Polygon Matic Archival                     | poly-archival             | 000B      |
 | Polygon Mumbai                             | polygon-mumbai            | 000F      |
 | Polygon zkEVM Mainnet                      | polygon-zkevm-mainnet     | 0074      |
-| Ropsten                                    | eth-ropsten               | 0023      |
+| Radix                                      | radix-mainnet             | 0083      |
 | Scroll Testnet                             | scroll-testnet            | 0075      |
-| Solana                                     | solana-mainnet            | 0006      |
+| Sepolia                                    | sepolia                   | 0077      |
+| Sepolia Archival                           | sepolia-archival          | 0078      |
+| Solana Mainnet                             | solana-mainnet            | 0006      |
+| Solana Mainnet Custom                      | solana-mainnet-custom     | C006      |
 | Starknet Mainnet                           | starknet-mainnet          | 0060      |
 | Starknet Testnet                           | starknet-testnet          | 0061      |
 | Sui Mainnet                                | sui-mainnet               | 0076      |
-| Swimmer Network Mainnet                    | avax-cra                  | 03CB      |
 | Velas Mainnet                              | velas-mainnet             | 0067      |
 | Velas Mainnet Archival                     | velas-mainnet-archival    | 0068      |
 


### PR DESCRIPTION
update chains to mainnet pocket supported chains as of RC-0.11.1  on March 3, 2024 running `pocket query supported-networks`
`http://pocket.dappnode:8081/v1/query/supportedchains`

```
 pocket query supported-networks 
http://pocket.dappnode:8081/v1/query/supportedchains
[
    "0001",
    "0003",
    "0004",
    "0005",
    "0006",
    "0009",
    "000A",
    "000B",
    "000C",
    "000F",
    "0010",
    "0012",
    "0021",
    "0022",
    "0024",
    "0025",
    "0026",
    "0027",
    "0028",
    "0040",
    "0044",
    "0046",
    "0047",
    "0048",
    "0049",
    "0050",
    "0051",
    "0052",
    "0053",
    "0054",
    "0056",
    "0057",
    "0058",
    "0059",
    "0060",
    "0061",
    "0063",
    "0065",
    "0066",
    "0067",
    "0068",
    "0069",
    "0070",
    "0071",
    "0072",
    "0074",
    "0075",
    "0076",
    "0077",
    "0078",
    "0079",
    "0080",
    "0081",
    "0082",
    "0083",
    "03DF",
    "A003",
    "A053",
    "A0CA",
    "C006"
]
```